### PR TITLE
Fix for staging32 lib redirection, added lib64 to dyldFallBackLibraryPath

### DIFF
--- a/WineskinApp/English.lproj/MainMenu.xib
+++ b/WineskinApp/English.lproj/MainMenu.xib
@@ -1221,8 +1221,8 @@ Gw
                                                 <action selector="winetricksButtonPressed:" target="494" id="807"/>
                                             </connections>
                                         </button>
-                                        <button id="737">
-                                            <rect key="frame" x="222" y="84" width="194" height="36"/>
+                                        <button misplaced="YES" id="737">
+                                            <rect key="frame" x="222" y="122" width="194" height="36"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="bevel" title="Custom EXE Creator" bezelStyle="regularSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="738">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1232,10 +1232,10 @@ Gw
                                                 <action selector="createCustomExeLauncherButtonPressed:" target="494" id="808"/>
                                             </connections>
                                         </button>
-                                        <button id="1644">
-                                            <rect key="frame" x="222" y="122" width="194" height="36"/>
+                                        <button misplaced="YES" id="1644">
+                                            <rect key="frame" x="16" y="46" width="194" height="36"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <buttonCell key="cell" type="bevel" title="Command Line Shell" bezelStyle="regularSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1645">
+                                            <buttonCell key="cell" type="bevel" title="Command Line (cmd)" bezelStyle="regularSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1645">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>
@@ -1265,8 +1265,8 @@ Gw
                                                 <action selector="taskmgrButtonPressed:" target="494" id="804"/>
                                             </connections>
                                         </button>
-                                        <button id="1475">
-                                            <rect key="frame" x="15" y="46" width="194" height="36"/>
+                                        <button misplaced="YES" id="1475">
+                                            <rect key="frame" x="16" y="8" width="194" height="36"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="bevel" title="Uninstaller (uninstaller)" bezelStyle="regularSquare" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1476">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1320,8 +1320,8 @@ Gw
                                                 <action selector="updateWrapperButtonPressed:" target="494" id="810"/>
                                             </connections>
                                         </button>
-                                        <button id="778">
-                                            <rect key="frame" x="222" y="46" width="194" height="36"/>
+                                        <button misplaced="YES" id="778">
+                                            <rect key="frame" x="223" y="84" width="194" height="36"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="bevel" title="View Last Run Log Files" bezelStyle="regularSquare" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="779">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1362,19 +1362,8 @@ Gw
                                             <rect key="frame" x="213" y="12" width="5" height="210"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         </box>
-                                        <button id="1918">
-                                            <rect key="frame" x="15" y="8" width="194" height="36"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                            <buttonCell key="cell" type="bevel" title="Command Line Wine Test" bezelStyle="regularSquare" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1919">
-                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="system"/>
-                                            </buttonCell>
-                                            <connections>
-                                                <action selector="commandLineWineTestButtonPressed:" target="494" id="1922"/>
-                                            </connections>
-                                        </button>
-                                        <button id="687">
-                                            <rect key="frame" x="222" y="8" width="194" height="36"/>
+                                        <button misplaced="YES" id="687">
+                                            <rect key="frame" x="223" y="8" width="194" height="36"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <buttonCell key="cell" type="bevel" title="Kill Wineskin Processes" bezelStyle="regularSquare" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="688">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -1388,6 +1377,17 @@ Gw
                                             <rect key="frame" x="420" y="12" width="5" height="210"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                         </box>
+                                        <button misplaced="YES" id="1918">
+                                            <rect key="frame" x="223" y="46" width="194" height="36"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <buttonCell key="cell" type="bevel" title="Command Line Wine Test" bezelStyle="regularSquare" imagePosition="overlaps" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1919">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="commandLineWineTestButtonPressed:" target="494" id="1922"/>
+                                            </connections>
+                                        </button>
                                     </subviews>
                                 </view>
                             </tabViewItem>

--- a/WineskinApp/WineskinAppDelegate.m
+++ b/WineskinApp/WineskinAppDelegate.m
@@ -548,7 +548,7 @@ NSFileManager *fm;
     [colorDepth setEnabled:YES];
     [switchPause setEnabled:YES];
     [useMacDriverInsteadOfX11CheckBoxButton setEnabled:NO];
-    [windowManagerCheckBoxButton setEnabled:YES];
+    [windowManagerCheckBoxButton setEnabled:NO];
     
     //on override, need to load all options
     [forceNormalWindowsUseTheseSettingsToggle deselectAllCells];
@@ -624,6 +624,7 @@ NSFileManager *fm;
     BOOL macDriver = useMacDriverInsteadOfX11CheckBoxButton.state;
     [windowManagerCheckBoxButton setEnabled:!macDriver];
 }
+
 - (IBAction)overrideClicked:(id)sender
 {
 	[forceNormalWindowsUseTheseSettingsToggle setEnabled:YES];
@@ -634,38 +635,41 @@ NSFileManager *fm;
 	[colorDepth setEnabled:YES];
 	[switchPause setEnabled:YES];
     [useMacDriverInsteadOfX11CheckBoxButton setEnabled:NO];
-    
-    [windowManagerCheckBoxButton setEnabled:YES];
-    
+    [windowManagerCheckBoxButton setEnabled:NO];
     [useMacDriverInsteadOfX11CheckBoxButton setState:NO];
     [NSWineskinPortDataWriter saveMacDriver:NO atPort:portManager];
-    
     [windowManagerCheckBoxButton setState:YES];
     [NSWineskinPortDataWriter saveDecorateWindow:YES atPort:portManager];
 }
+
 - (IBAction)rootlessClicked:(id)sender
 {
 	[fullscreenRootlesToggleTabView selectFirstTabViewItem:self];
     [virtualDesktopResolution setEnabled:![normalWindowsVirtualDesktopToggleNormalWindowsButton intValue]];
 }
+
 - (IBAction)fullscreenClicked:(id)sender
 {
 	[fullscreenRootlesToggleTabView selectLastTabViewItem:self];
 }
+
 - (IBAction)normalWindowsClicked:(id)sender
 {
 	[virtualDesktopResolution setEnabled:NO];
 }
+
 - (IBAction)virtualDesktopClicked:(id)sender
 {
 	[virtualDesktopResolution setEnabled:YES];
 }
+
 - (IBAction)gammaChanged:(id)sender
 {
 	if ([gammaSlider doubleValue] != 60.0)
 		[self systemCommand:[NSString stringWithFormat:@"%@/Contents/Resources/WSGamma",[[NSBundle mainBundle] bundlePath]]
                    withArgs:@[[NSString stringWithFormat:@"%1.2f",(100.0-([gammaSlider doubleValue]-60))/100]]];
 }
+
 - (IBAction)windowManagerCheckBoxClicked:(id)sender
 {
     [NSWineskinPortDataWriter saveDecorateWindow:windowManagerCheckBoxButton.state atPort:portManager];
@@ -708,11 +712,13 @@ NSFileManager *fm;
         }
 	}
 }
+
 - (IBAction)commandLineWineTestButtonPressed:(id)sender
 {
 	[self saveAllData];
 	[NSThread detachNewThreadSelector:@selector(runACommandLineTestRun) toTarget:self withObject:nil];
 }
+
 - (void)runACommandLineTestRun
 {
 	@autoreleasepool
@@ -720,6 +726,7 @@ NSFileManager *fm;
 		system([[NSString stringWithFormat: @"export PATH=\"%@/bin:$PATH\";open -a Terminal.app \"%@/Contents/Resources/Command Line Wine Test\"",self.wswineBundlePath,[[NSBundle mainBundle] bundlePath]] UTF8String]);
 	}
 }
+
 - (IBAction)killWineskinProcessesButtonPressed:(id)sender
 {
     //get name of wine and wineserver
@@ -813,6 +820,7 @@ NSFileManager *fm;
     [portManager setPlistObject:wineDebugTextField.stringValue      forKey:@"WINEDEBUG="];
     [portManager synchronizePlist];
 }
+
 - (void)loadAllData
 {
 	//get wrapper version and put on Advanced Page wrapperVersionText

--- a/WineskinLauncher/WineskinLauncherAppDelegate.m
+++ b/WineskinLauncher/WineskinLauncherAppDelegate.m
@@ -1751,8 +1751,7 @@ static NSPortManager* portManager;
 - (void)fixWineStagingExecutableNames
 {
     BOOL fixWine=YES;
-    NSString *oldWineName = nil;
-
+    NSString *oldWineServerName = nil;
     NSString *pathToWineBinFolder = [NSString stringWithFormat:@"%@/wswine.bundle/bin",frameworksFold];
     NSArray *engineBinContents = [fm contentsOfDirectoryAtPath:pathToWineBinFolder];
     for (NSString *item in engineBinContents)
@@ -1794,8 +1793,6 @@ static NSPortManager* portManager;
     NSString* binBash = @"#!/bin/bash\n";
     NSString* dyldFallbackLibraryPath = @"DYLD_FALLBACK_LIBRARY_PATH=\"${WINESKIN_LIB_PATH_FOR_FALLBACK}\"";
     
-    NSString *wineBash = [NSString stringWithFormat:@"%@%@ \"$(dirname \"$0\")/%@\" \"$@\"",
-                          
     NSString *wineServerBash = [NSString stringWithFormat:@"%@%@ \"$(dirname \"$0\")/%@\" \"$@\"",
                                 binBash,dyldFallbackLibraryPath,wineServerName];
     


### PR DESCRIPTION
Staging32 lib redirection fixed, forgot to remove it before
Slight edit to Advance Tool's Menu options
Screen options Disabled decorate Windows when using override was discussed in last issue
wswine.bundle/lib64 no added to dyldFallBackLibraryPath