### PR TITLE
Fixed wine-kill error 

### DIFF
--- a/WineskinApp/WineskinAppDelegate.m
+++ b/WineskinApp/WineskinAppDelegate.m
@@ -763,7 +763,7 @@ NSFileManager *fm;
         {
             wine64Name = [item copy];
         }
-        if ([item hasSuffix:@"WineStagingName"])
+        if ([item hasSuffix:@"Wine-preloader"])
         {
             wineStagingName = [item copy];
         }

--- a/WineskinLauncher/WineskinLauncherAppDelegate.m
+++ b/WineskinLauncher/WineskinLauncherAppDelegate.m
@@ -1462,7 +1462,7 @@ static NSPortManager* portManager;
 	}
     
 	//make/remake the symlink in wswine.bundle to point to the correct location
-    for (NSString* folder in @[@"bin", @"lib", @"share", @"version"])
+    for (NSString* folder in @[@"bin", @"lib", @"lib64", @"share", @"version"])
     {
         [fm removeItemAtPath:[NSString stringWithFormat:@"%@/%@",wswineBundlePath,folder]];
         [fm createSymbolicLinkAtPath:[NSString stringWithFormat:@"%@/%@",wswineBundlePath,folder]


### PR DESCRIPTION
Now correctly kills wine-preloader
Added symlink lib64 to wswine.bundle for wineskinlauncher