### PR TITLE
Fixed Wine Executable Renaming+

### DIFF
--- a/WineskinApp/WineskinAppDelegate.h
+++ b/WineskinApp/WineskinAppDelegate.h
@@ -238,8 +238,8 @@
 - (IBAction)killWineskinProcessesButtonPressed:(id)sender;
 - (void)killWine32;
 - (void)killWine64;
-- (void)killStaging;
-- (void)killStaging64;
+- (void)killWineStaging;
+- (void)killWineStaging64;
 
 //advanced menu - Configuration Tab
 - (void)saveAllData;

--- a/WineskinApp/WineskinAppDelegate.h
+++ b/WineskinApp/WineskinAppDelegate.h
@@ -236,6 +236,10 @@
 - (IBAction)commandLineWineTestButtonPressed:(id)sender;
 - (void)runATestRun;
 - (IBAction)killWineskinProcessesButtonPressed:(id)sender;
+- (void)killWine32;
+- (void)killWine64;
+- (void)killStaging;
+- (void)killStaging64;
 
 //advanced menu - Configuration Tab
 - (void)saveAllData;

--- a/WineskinApp/WineskinAppDelegate.m
+++ b/WineskinApp/WineskinAppDelegate.m
@@ -741,11 +741,31 @@ NSFileManager *fm;
 
 - (IBAction)killWineskinProcessesButtonPressed:(id)sender
 {
+    NSString *pathToWineBinFolder = [NSString stringWithFormat:@"%@/bin",self.wswineBundlePath];
+    
+    if     ([fm fileExistsAtPath:[NSString stringWithFormat:@"%@/wine64-preloader",pathToWineBinFolder]])
+    {
+        [self killWineStaging64];
+    }
+    else if     ([fm fileExistsAtPath:[NSString stringWithFormat:@"%@/wine64",pathToWineBinFolder]])
+    {
+        [self killWine64];
+    }
+    else if     ([fm fileExistsAtPath:[NSString stringWithFormat:@"%@/wine-preloader",pathToWineBinFolder]])
+    {
+        [self killWineStaging];
+    }
+    else
+    {
+        [self killWine32];
+    }
+    
+}
+
+- (void)killWine32
+{
     //get name of wine and wineserver
     NSString *wineName = @"wine";
-    NSString *wineStagingName = @"wine-preloader";
-    NSString *wine64Name = @"wine64";
-    NSString *wine64StagingName= @"wine64-preloader";
     NSString *wineserverName = @"wineserver";
     NSArray *filesTEMP1 = [fm subpathsOfDirectoryAtPath:[NSString stringWithFormat:@"%@/bin",self.wswineBundlePath] error:nil];
     for (NSString *item in filesTEMP1)
@@ -754,10 +774,189 @@ NSFileManager *fm;
         {
             wineName = [item copy];
         }
+        else if ([item hasSuffix:@"Wineserver"])
+        {
+            wineserverName = [item copy];
+        }
+    }
+	//give warning message
+    if ([NSAlert showBooleanAlertOfType:NSAlertTypeWarning withMessage:[NSString stringWithFormat:@"This will kill the following processes (if running) from this wrapper...\n\nWineskinLauncher\nWineskinX11\n%@\n%@\n\nAre you sure that you want to kill these processes TESTING?",wineName,wineserverName] withDefault:NO])
+    {
+    	//kill WineskinLauncher WineskinX11 wine wineserver
+        [self systemCommand:[NSString stringWithFormat:@"killall -m %@",wineName]];
+        [self systemCommand:[NSString stringWithFormat:@"killall -m %@",wineserverName]];
+        
+        NSMutableArray *pidsToKill = [[NSMutableArray alloc] init];
+        [pidsToKill addObjectsFromArray:[[self systemCommand:[NSString stringWithFormat:@"ps ax | grep \"%@\" | grep WineskinX11 | awk \"{print \\$1}\"",self.wrapperPath]] componentsSeparatedByString:@"\n"]];
+        [pidsToKill addObjectsFromArray:[[self systemCommand:[NSString stringWithFormat:@"ps ax | grep \"%@\" | grep WineskinLauncher | awk \"{print \\$1}\"",self.wrapperPath]] componentsSeparatedByString:@"\n"]];
+        
+        for (NSString *pid in pidsToKill)
+        {
+            [self systemCommand:[NSString stringWithFormat:@"kill -9 %@",pid]];
+        }
+    }
+    //clear launchd entries that may be stuck
+    NSString *wrapperPath = self.wrapperPath;
+    NSString *wrapperName = [[wrapperPath substringFromIndex:[wrapperPath rangeOfString:@"/" options:NSBackwardsSearch].location+1] stringByDeletingPathExtension];
+    NSString *results = [self systemCommand:[NSString stringWithFormat:@"launchctl list | grep \"%@\"",wrapperName]];
+    NSArray *resultArray = [results componentsSeparatedByString:@"\n"];
+    for (NSString *result in resultArray)
+    {
+        NSRange theDash = [result rangeOfString:@"-"];
+        if (theDash.location != NSNotFound)
+        {
+            // clear in front of - in case launchd has it as anonymous, then clear after first [
+            NSString *entryToRemove = [[result substringFromIndex:theDash.location+1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+            NSRange theBracket = [entryToRemove rangeOfString:@"["];
+            if (theBracket.location != NSNotFound) {
+                entryToRemove = [entryToRemove substringFromIndex:theBracket.location];
+            }
+            NSLog(@"launchctl remove \"%@\"",entryToRemove);
+            [self systemCommand:[NSString stringWithFormat:@"launchctl remove \"%@\"",entryToRemove]];
+        }
+    }
+    //delete lockfile
+    NSString *tmpFolder=[NSString stringWithFormat:@"/tmp/%@",[self.wrapperPath stringByReplacingOccurrencesOfString:@"/" withString:@"xWSx"]];
+    NSString *lockfile=[NSString stringWithFormat:@"%@/lockfile",tmpFolder];
+    [fm removeItemAtPath:lockfile];
+    [fm removeItemAtPath:tmpFolder];
+}
+
+- (void)killWine64
+{
+    //get name of wine and wineserver
+    NSString *wineName = @"wine";
+    NSString *wine64Name = @"wine64";
+    NSString *wineserverName = @"wineserver";
+    NSArray *filesTEMP1 = [fm subpathsOfDirectoryAtPath:[NSString stringWithFormat:@"%@/bin",self.wswineBundlePath] error:nil];
+    for (NSString *item in filesTEMP1)
+    {
+        if ([item hasSuffix:@"Wine"])
+        {
+            wineName = [item copy];
+        }
         if ([item hasSuffix:@"Wine64"])
         {
             wine64Name = [item copy];
         }
+        else if ([item hasSuffix:@"Wineserver"])
+        {
+            wineserverName = [item copy];
+        }
+    }
+    //give warning message
+    if ([NSAlert showBooleanAlertOfType:NSAlertTypeWarning withMessage:[NSString stringWithFormat:@"This will kill the following processes (if running) from this wrapper...\n\nWineskinLauncher\nWineskinX11\n%@\n%@/n%@\n\nAre you sure that you want to kill these processes?",wineName,wine64Name,wineserverName] withDefault:NO])
+    {
+        //kill WineskinLauncher WineskinX11 wine wineserver
+        [self systemCommand:[NSString stringWithFormat:@"killall -m %@",wineName]];
+        [self systemCommand:[NSString stringWithFormat:@"killall -m %@",wine64Name]];
+        [self systemCommand:[NSString stringWithFormat:@"killall -m %@",wineserverName]];
+        
+        NSMutableArray *pidsToKill = [[NSMutableArray alloc] init];
+        [pidsToKill addObjectsFromArray:[[self systemCommand:[NSString stringWithFormat:@"ps ax | grep \"%@\" | grep WineskinX11 | awk \"{print \\$1}\"",self.wrapperPath]] componentsSeparatedByString:@"\n"]];
+        [pidsToKill addObjectsFromArray:[[self systemCommand:[NSString stringWithFormat:@"ps ax | grep \"%@\" | grep WineskinLauncher | awk \"{print \\$1}\"",self.wrapperPath]] componentsSeparatedByString:@"\n"]];
+        
+        for (NSString *pid in pidsToKill)
+        {
+            [self systemCommand:[NSString stringWithFormat:@"kill -9 %@",pid]];
+        }
+    }
+    //clear launchd entries that may be stuck
+    NSString *wrapperPath = self.wrapperPath;
+    NSString *wrapperName = [[wrapperPath substringFromIndex:[wrapperPath rangeOfString:@"/" options:NSBackwardsSearch].location+1] stringByDeletingPathExtension];
+    NSString *results = [self systemCommand:[NSString stringWithFormat:@"launchctl list | grep \"%@\"",wrapperName]];
+    NSArray *resultArray = [results componentsSeparatedByString:@"\n"];
+    for (NSString *result in resultArray)
+    {
+        NSRange theDash = [result rangeOfString:@"-"];
+        if (theDash.location != NSNotFound)
+        {
+            // clear in front of - in case launchd has it as anonymous, then clear after first [
+            NSString *entryToRemove = [[result substringFromIndex:theDash.location+1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+            NSRange theBracket = [entryToRemove rangeOfString:@"["];
+            if (theBracket.location != NSNotFound) {
+                entryToRemove = [entryToRemove substringFromIndex:theBracket.location];
+            }
+            NSLog(@"launchctl remove \"%@\"",entryToRemove);
+            [self systemCommand:[NSString stringWithFormat:@"launchctl remove \"%@\"",entryToRemove]];
+        }
+    }
+    //delete lockfile
+    NSString *tmpFolder=[NSString stringWithFormat:@"/tmp/%@",[self.wrapperPath stringByReplacingOccurrencesOfString:@"/" withString:@"xWSx"]];
+    NSString *lockfile=[NSString stringWithFormat:@"%@/lockfile",tmpFolder];
+    [fm removeItemAtPath:lockfile];
+    [fm removeItemAtPath:tmpFolder];
+}
+
+- (void)killWineStaging
+{
+    //get name of wine and wineserver
+    NSString *wineStagingName = @"wine-preloader";
+    NSString *wineserverName = @"wineserver";
+    NSArray *filesTEMP1 = [fm subpathsOfDirectoryAtPath:[NSString stringWithFormat:@"%@/bin",self.wswineBundlePath] error:nil];
+    for (NSString *item in filesTEMP1)
+    {
+        if ([item hasSuffix:@"Wine-preloader"])
+        {
+            wineStagingName = [item copy];
+        }
+        else if ([item hasSuffix:@"Wineserver"])
+        {
+            wineserverName = [item copy];
+        }
+    }
+    //give warning message
+    if ([NSAlert showBooleanAlertOfType:NSAlertTypeWarning withMessage:[NSString stringWithFormat:@"This will kill the following processes (if running) from this wrapper...\n\nWineskinLauncher\nWineskinX11\n%@\n%@\n\nAre you sure that you want to kill these processes?",wineStagingName,wineserverName] withDefault:NO])
+    {
+        //kill WineskinLauncher WineskinX11 wine wineserver
+        [self systemCommand:[NSString stringWithFormat:@"killall -m %@",wineStagingName]];
+        [self systemCommand:[NSString stringWithFormat:@"killall -m %@",wineserverName]];
+        
+        NSMutableArray *pidsToKill = [[NSMutableArray alloc] init];
+        [pidsToKill addObjectsFromArray:[[self systemCommand:[NSString stringWithFormat:@"ps ax | grep \"%@\" | grep WineskinX11 | awk \"{print \\$1}\"",self.wrapperPath]] componentsSeparatedByString:@"\n"]];
+        [pidsToKill addObjectsFromArray:[[self systemCommand:[NSString stringWithFormat:@"ps ax | grep \"%@\" | grep WineskinLauncher | awk \"{print \\$1}\"",self.wrapperPath]] componentsSeparatedByString:@"\n"]];
+        
+        for (NSString *pid in pidsToKill)
+        {
+            [self systemCommand:[NSString stringWithFormat:@"kill -9 %@",pid]];
+        }
+    }
+    //clear launchd entries that may be stuck
+    NSString *wrapperPath = self.wrapperPath;
+    NSString *wrapperName = [[wrapperPath substringFromIndex:[wrapperPath rangeOfString:@"/" options:NSBackwardsSearch].location+1] stringByDeletingPathExtension];
+    NSString *results = [self systemCommand:[NSString stringWithFormat:@"launchctl list | grep \"%@\"",wrapperName]];
+    NSArray *resultArray = [results componentsSeparatedByString:@"\n"];
+    for (NSString *result in resultArray)
+    {
+        NSRange theDash = [result rangeOfString:@"-"];
+        if (theDash.location != NSNotFound)
+        {
+            // clear in front of - in case launchd has it as anonymous, then clear after first [
+            NSString *entryToRemove = [[result substringFromIndex:theDash.location+1] stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
+            NSRange theBracket = [entryToRemove rangeOfString:@"["];
+            if (theBracket.location != NSNotFound) {
+                entryToRemove = [entryToRemove substringFromIndex:theBracket.location];
+            }
+            NSLog(@"launchctl remove \"%@\"",entryToRemove);
+            [self systemCommand:[NSString stringWithFormat:@"launchctl remove \"%@\"",entryToRemove]];
+        }
+    }
+    //delete lockfile
+    NSString *tmpFolder=[NSString stringWithFormat:@"/tmp/%@",[self.wrapperPath stringByReplacingOccurrencesOfString:@"/" withString:@"xWSx"]];
+    NSString *lockfile=[NSString stringWithFormat:@"%@/lockfile",tmpFolder];
+    [fm removeItemAtPath:lockfile];
+    [fm removeItemAtPath:tmpFolder];
+}
+
+- (void)killWineStaging64
+{
+    //get name of wine and wineserver
+    NSString *wineStagingName = @"wine-preloader";
+    NSString *wine64StagingName= @"wine64-preloader";
+    NSString *wineserverName = @"wineserver";
+    NSArray *filesTEMP1 = [fm subpathsOfDirectoryAtPath:[NSString stringWithFormat:@"%@/bin",self.wswineBundlePath] error:nil];
+    for (NSString *item in filesTEMP1)
+    {
         if ([item hasSuffix:@"Wine-preloader"])
         {
             wineStagingName = [item copy];
@@ -771,15 +970,13 @@ NSFileManager *fm;
             wineserverName = [item copy];
         }
     }
-	//give warning message
-    if ([NSAlert showBooleanAlertOfType:NSAlertTypeWarning withMessage:[NSString stringWithFormat:@"This will kill the following processes (if running) from this wrapper...\n\nWineskinLauncher\nWineskinX11\n%@\n%@\n\nAre you sure that you want to kill these processes?",wineName,wineserverName] withDefault:NO])
+    //give warning message
+    if ([NSAlert showBooleanAlertOfType:NSAlertTypeWarning withMessage:[NSString stringWithFormat:@"This will kill the following processes (if running) from this wrapper...\n\nWineskinLauncher\nWineskinX11\n%@\n%@\n%@\n\nAre you sure that you want to kill these processes?",wineStagingName,wine64StagingName,wineserverName] withDefault:NO])
     {
-    	//kill WineskinLauncher WineskinX11 wine wineserver
-        [self systemCommand:[NSString stringWithFormat:@"killall -9 %@",wineName]];
-        [self systemCommand:[NSString stringWithFormat:@"killall -9 %@",wineStagingName]];
-        [self systemCommand:[NSString stringWithFormat:@"killall -9 %@",wine64Name]];
-        [self systemCommand:[NSString stringWithFormat:@"killall -9 %@",wine64StagingName]];
-        [self systemCommand:[NSString stringWithFormat:@"killall -9 %@",wineserverName]];
+        //kill WineskinLauncher WineskinX11 wine wineserver
+        [self systemCommand:[NSString stringWithFormat:@"killall -m %@",wineStagingName]];
+        [self systemCommand:[NSString stringWithFormat:@"killall -m %@",wine64StagingName]];
+        [self systemCommand:[NSString stringWithFormat:@"killall -m %@",wineserverName]];
         
         NSMutableArray *pidsToKill = [[NSMutableArray alloc] init];
         [pidsToKill addObjectsFromArray:[[self systemCommand:[NSString stringWithFormat:@"ps ax | grep \"%@\" | grep WineskinX11 | awk \"{print \\$1}\"",self.wrapperPath]] componentsSeparatedByString:@"\n"]];

--- a/WineskinApp/Winetricks/winetricks
+++ b/WineskinApp/Winetricks/winetricks
@@ -5342,7 +5342,8 @@ helper_winxpsp3()
     # https://www.microsoft.com/en-us/download/details.aspx?id=24
     # https://download.microsoft.com/download/d/3/0/d30e32d8-418a-469d-b600-f32ce3edf42d/WindowsXP-KB936929-SP3-x86-ENU.exe
     # Mirror list: http://www.filewatcher.com/m/WindowsXP-KB936929-SP3-x86-ENU.exe.331805736-0.html
-    w_download_to winxpsp3 ftp://ftp.gnome.org/mirror/archive/ftp.sunet.se/pub/security/vendor/microsoft/winxp/Service_Packs/WindowsXP-KB936929-SP3-x86-ENU.exe 62e524a552db9f6fd22d469010ea4d7e28ee06fa615a1c34362129f808916654
+    # 2018/04/04: http://www.download.windowsupdate.com/msdownload/update/software/dflt/2008/04/windowsxp-kb936929-sp3-x86-enu_c81472f7eeea2eca421e116cd4c03e2300ebfde4.exe
+    w_download_to winxpsp3 ftp://ftp.emacinc.com/LegacyProducts/SBC/drivers/vdx/WINXP/WindowsXP-KB936929-SP3-x86-ENU.exe 62e524a552db9f6fd22d469010ea4d7e28ee06fa615a1c34362129f808916654
 
     w_try_cabextract -d "$W_TMP" -L -F "$filename" "$W_CACHE"/winxpsp3/WindowsXP-KB936929-SP3-x86-ENU.exe
 }
@@ -5416,6 +5417,8 @@ load_amstream()
         helper_win7sp1_x64 amd64_microsoft-windows-directshow-other_31bf3856ad364e35_6.1.7601.17514_none_6b778d68f75a1a54/amstream.dll
         w_try cp "$W_TMP/amd64_microsoft-windows-directshow-other_31bf3856ad364e35_6.1.7601.17514_none_6b778d68f75a1a54/amstream.dll" "$W_SYSTEM64_DLLS/amstream.dll"
     fi
+
+    w_try_regsvr amstream.dll
 
     w_override_dlls native,builtin amstream
 }
@@ -12319,53 +12322,6 @@ _EOF_
 
 #----------------------------------------------------------------
 
-w_metadata picasa39 apps \
-    title="Picasa 3.9" \
-    publisher="Google" \
-    year="2014" \
-    file1="picasa39-setup.exe" \
-    installed_exe1="$W_PROGRAMS_X86_WIN/Google/Picasa3/Picasa3.exe"
-
-load_picasa39()
-{
-    # 2016/01/02: 482c1a547d8d3aa25ee446d30ea986de63ef8c8d68b8d1109dd3d9b714e73e08
-
-    w_download https://dl.google.com/picasa/picasa39-setup.exe 482c1a547d8d3aa25ee446d30ea986de63ef8c8d68b8d1109dd3d9b714e73e08
-    if w_workaround_wine_bug 29434 "Picasa 3.9 fails to authenticate with Google"; then
-        w_warn "Picasa 3.9 authentication to the Google account is currently broken under wine. See https://bugs.winehq.org/show_bug.cgi?id=29434 for more details."
-    fi
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_ahk_do "
-        SetTitleMatchMode, 2
-        run picasa39-setup.exe
-        WinWait, Picasa 3 Setup
-        if ( w_opt_unattended > 0 ) {
-             Sleep 1000
-             ControlClick Button2 ;I Agree - License
-             Sleep 1000
-             WinWait, Picasa 3 Setup, Choose Install Location
-             ControlClick Button2 ;Install
-             Sleep 1000
-             WinWait, Picasa 3 Setup, Picasa 3 has been installed on your computer
-             Sleep 500
-             ControlClick Button5 ; Desktop Icon
-             Sleep 500
-             ControlClick Button6 ; Quick Launch
-             Sleep 500
-             ControlClick Button7 ; Default search off
-             Sleep 500
-             ControlClick Button8 ; Usage statistics sent
-             Sleep 500
-             ControlClick Button4 ; Run Picasa
-             Sleep 500
-             ControlClick Button2 ; Finish
-        }
-        WinWaitClose
-        "
-}
-
-#----------------------------------------------------------------
-
 w_metadata protectionid apps \
     title="Protection ID" \
     publisher="CDKiLLER & TippeX" \
@@ -16750,40 +16706,6 @@ load_penpenxmas()
 
     w_try_cd "$W_CACHE/$W_PACKAGE"
     "$WINE" PenPenXmasOlympics100.exe $W_UNATTENDED_SLASH_S
-}
-
-#----------------------------------------------------------------
-
-w_metadata plantsvszombies games \
-    title="Plants vs. Zombies" \
-    publisher="PopCap Games" \
-    year="2009" \
-    media="download" \
-    file1="PlantsVsZombiesSetup.exe" \
-    installed_file1="$W_PROGRAMS_X86_WIN/PopCap Games/Plants vs. Zombies/PlantsVsZombies.exe"
-
-load_plantsvszombies()
-{
-    w_download "https://downloads.popcap.com/www/popcap_downloads/PlantsVsZombiesSetup.exe" 4b4bb4d19fb639e5698983e39d7ad061c7667bcec19056560532c7ad0d67d0e4
-
-    w_try_cd "$W_CACHE/$W_PACKAGE"
-    w_ahk_do "
-        run PlantsVsZombiesSetup.exe
-        winwait, Plants vs. Zombies Installer
-        if ( w_opt_unattended > 0 ) {
-            sleep 1000
-            send {Enter}
-            winwait, Plants vs. Zombies License Agreement
-            ControlClick Button1
-        }
-        winwait, Plants vs. Zombies Installation Complete!
-        if ( w_opt_unattended > 0 ) {
-            sleep 1000
-            send {Space}{Enter}
-            ControlClick, x309 y278, Plants vs. Zombies Installation Complete!,,,, Pos
-        }
-        WinWaitClose
-    "
 }
 
 #----------------------------------------------------------------

--- a/WineskinApp/Winetricks/winetricksHelpList.plist
+++ b/WineskinApp/Winetricks/winetricksHelpList.plist
@@ -256,13 +256,6 @@
 			<key>WS-Name</key>
 			<string>openwatcom</string>
 		</dict>
-		<key>picasa39</key>
-		<dict>
-			<key>WS-Description</key>
-			<string>Picasa 3.9</string>
-			<key>WS-Name</key>
-			<string>picasa39</string>
-		</dict>
 		<key>protectionid</key>
 		<dict>
 			<key>WS-Description</key>
@@ -2381,13 +2374,6 @@
 			<string>Pen-Pen Xmas Olympics</string>
 			<key>WS-Name</key>
 			<string>penpenxmas</string>
-		</dict>
-		<key>plantsvszombies</key>
-		<dict>
-			<key>WS-Description</key>
-			<string>Plants vs. Zombies</string>
-			<key>WS-Name</key>
-			<string>plantsvszombies</string>
 		</dict>
 		<key>popfs</key>
 		<dict>

--- a/WineskinApp/remakedefaults.reg
+++ b/WineskinApp/remakedefaults.reg
@@ -67,6 +67,10 @@ REGEDIT4
 "StartUp"="C:\\users\\Wineskin\\Start Menu\\Programs\\StartUp"
 "Templates"="C:\\users\\Wineskin\\Templates"
 
+[HKEY_CURRENT_USER\Environment]
+"TEMP"="C:\\users\\Wineskin\\Temp"
+"TMP"="C:\\users\\Wineskin\\Temp"
+
 [HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders]
 "AppData"=str(2):"%USERPROFILE%\\Application Data"
 "Cache"=str(2):"%USERPROFILE%\\Local Settings\\Temporary Internet Files"

--- a/WineskinLauncher/WineskinLauncherAppDelegate.m
+++ b/WineskinLauncher/WineskinLauncherAppDelegate.m
@@ -2399,7 +2399,10 @@ static NSPortManager* portManager;
     
     //kill processes
     [self systemCommand:[NSString stringWithFormat:@"killall -9 \"%@\" > /dev/null 2>&1", wineName]];
-    
+    [self systemCommand:[NSString stringWithFormat:@"killall -9 \"%@\" > /dev/null 2>&1", wine64Name]];
+    [self systemCommand:[NSString stringWithFormat:@"killall -9 \"%@\" > /dev/null 2>&1", wineStagingName]];
+    [self systemCommand:[NSString stringWithFormat:@"killall -9 \"%@\" > /dev/null 2>&1", wineStaging64Name]];
+
     //get rid of OS X saved state file
     [fm removeItemAtPath:[NSString stringWithFormat:@"%@/Library/Saved Application State/%@%@.wineskin.prefs.savedState",NSHomeDirectory(),[[NSNumber numberWithLong:bundleRandomInt1] stringValue],[[NSNumber numberWithLong:bundleRandomInt2] stringValue]]];
     

--- a/WineskinLauncher/WineskinLauncherAppDelegate.m
+++ b/WineskinLauncher/WineskinLauncherAppDelegate.m
@@ -1096,7 +1096,7 @@ static NSPortManager* portManager;
     
     if (![fm fileExistsAtPath:[NSString stringWithFormat:@"%@/%@",frameworksFold,mainFile]])
     {
-        [mainFile setString:@"/usr/lib/libXplugin.1.10.8.dylib"];//default to 10.8 for 10.9+
+        [mainFile setString:@"libXplugin.1.10.8.dylib"];//default to 10.8 for 10.9+
     }
     
     [fm removeItemAtPath:symlinkName];
@@ -1640,8 +1640,11 @@ static NSPortManager* portManager;
         [fm removeItemAtPath:[NSString stringWithFormat:@"%@/wine",pathToWineBinFolder]];
         [fm removeItemAtPath:[NSString stringWithFormat:@"%@/wineserver",pathToWineBinFolder]];
         
+        
+        dyldFallBackLibraryPath = [NSString stringWithFormat:@"/opt/X11/lib:/opt/local/lib:%@:%@/wswine.bundle/lib:/usr/lib:/usr/libexec:/usr/lib/system:/usr/X11/lib:/usr/X11R6/lib",frameworksFold,frameworksFold];
+        
         NSString* binBash = @"#!/bin/bash\n";
-        NSString* dyldFallbackLibraryPath = @"DYLD_FALLBACK_LIBRARY_PATH=\"${WINESKIN_LIB_PATH_FOR_FALLBACK}\"";
+        NSString *dyldFallbackLibraryPath =  [NSString stringWithFormat:@"DYLD_FALLBACK_LIBRARY_PATH=\"%@\"",dyldFallBackLibraryPath];
         
         NSString *wineBash = [NSString stringWithFormat:@"%@%@ \"$(dirname \"$0\")/%@\" \"$@\"",
                               binBash,dyldFallbackLibraryPath,wineName];


### PR DESCRIPTION
Now Wine Staging/Staging64 have custom names without breaking or causes them to not build all required files.

Added TEMP/TMP to renamedefaults.reg and set to WineSkin user folder, helps when removing user symlinks form Users folder so applications will not break due to deleted symlinked User folder.

fixFrameworksLibraries was trying to link to /usr/lib/libXplugin.1.10.8.dylib as fallback corrected to use the one in the frameworks folder instead.